### PR TITLE
Fix code coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,6 @@ deps =
     pytest-cov
     scipy
     torch
-commands = pytest --cov=./ --cov-report=xml -o pythonpath=
+commands = pytest --cov=./ --cov=exo --cov-report=xml -o pythonpath=
 passenv =
     SDE_PATH


### PR DESCRIPTION
Fix the coverage command to explicitly include the `exo` package.